### PR TITLE
refactor(getUsers): remove unnecessary try catch.

### DIFF
--- a/src/utils/getUsers.js
+++ b/src/utils/getUsers.js
@@ -1,20 +1,15 @@
 import withQuery from 'with-query';
 
 export const getUsers = async (id) => {
-  try {
-    const resp = await fetch(
-      withQuery('https://my-json-server.typicode.com/kristof0425/hacktoberfest-2017/users', id),
-      {
-        method: 'GET',
-        'Content-Type': 'application/json',
-        headers: {
-          'Accept': 'application/json'
-        }
+  const resp = await fetch(
+    withQuery('https://my-json-server.typicode.com/kristof0425/hacktoberfest-2017/users', id),
+    {
+      method: 'GET',
+      'Content-Type': 'application/json',
+      headers: {
+        'Accept': 'application/json'
       }
-    );
-    const results = await resp.json();
-    return results;
-  } catch (e) {
-    throw new Error(e);
-  }
+    }
+  );
+  return await resp.json();
 };


### PR DESCRIPTION
The try catch part can be removed because it has no any additional benefits. Basically, you're just catching the error to do exactly the same what JS does behind the curtain.